### PR TITLE
Fixing Contact Number (Numeric Only)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,13 @@
 - Bio: Project Admin | Software Engineer
 - GitHub: [Syed Imtiyaz Ali](https://github.com/SyedImtiyaz-1/)
 
+#### Name: [Ankit Matth](https://github.com/Ankit-Matth)
+
+- Place: Bhiwani, Haryana, India
+- Bio: Engineering Student | Passionate Frontend Developer
+- GitHub: [Ankit-Matth](https://github.com/Ankit-Matth)
+- Linkedin [@ankit-matth](https://www.linkedin.com/in/ankit-matth)
+
 #### Name: [Abhinav Srivastav](https://github.com/Abhinavrajsrivastav)
 
 - Place: Ghaziabad, India

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
         />
         <span id="name-error" class="error"></span> <!-- Validation error message for Name -->
         <input
-          type="tel"
+          type="number"
           id="number"
           name="phone"
           pattern="[0-9]{10,12}"


### PR DESCRIPTION
As we all know, input type="tel" defines a field for entering a phone number. But some older versions of some browsers do not support the value  "tel", so I changed the value of the type attribute of the input tag from "tel" to "number", so that it only takes numbers as input and not any character.

Fixes #236 

Sir, I have fixed this issue. Please merge my pull request with the "hacktoberfest-accepted" tag. And, also add a hacktoberfest tag to the issue #236.